### PR TITLE
Fix: Update git clone URLs in README files

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,7 @@ This project is a monorepo managed using [Turborepo](https://turbo.build/repo). 
 
 1.  Clone the project repository:
     ```bash
-    git clone https://github.com/username/noob.gg.git
+    git clone https://github.com/altudev/noob.gg.git
     cd noob.gg
     ```
 2.  Install the dependencies:

--- a/README.tr.md
+++ b/README.tr.md
@@ -18,7 +18,7 @@ Bu proje bir monorepo yapısındadır ve [Turborepo](https://turbo.build/repo) k
 
 1.  Proje dosyalarını klonlayın:
     ```bash
-    git clone https://github.com/kullanici/noob.gg.git
+    git clone https://github.com/altudev/noob.gg.git
     cd noob.gg
     ```
 2.  Gerekli bağımlılıkları yükleyin:


### PR DESCRIPTION
I've updated the git clone URLs in README.en.md and README.tr.md to point to the correct repository under the "altudev" GitHub username.

- I replaced "https://github.com/username/noob.gg.git" with "https://github.com/altudev/noob.gg.git" in README.en.md.
- I replaced "https://github.com/kullanici/noob.gg.git" with "https://github.com/altudev/noob.gg.git" in README.tr.md.