### PR TITLE
Add Game and Distributor schemas

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,8 +1,23 @@
-import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+import { integer, pgTable, varchar, text } from "drizzle-orm/pg-core";
 
 export const usersTable = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   name: varchar({ length: 255 }).notNull(),
   age: integer().notNull(),
   email: varchar({ length: 255 }).notNull().unique(),
+});
+
+export const gamesTable = pgTable("games", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar({ length: 255 }).notNull(),
+  description: text(),
+  logo: varchar({ length: 255 }),
+});
+
+export const distributorsTable = pgTable("distributors", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar({ length: 255 }).notNull(),
+  description: text(),
+  website: varchar({ length: 255 }),
+  logo: varchar({ length: 255 }),
 });


### PR DESCRIPTION
## Summary
- expand schema to include `games` and `distributors` tables for Drizzle ORM

## Testing
- `bun test`
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4250b72c8331a7a402aeac0b86e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for managing games, including details such as name, description, and logo.
	- Added support for managing distributors, including name, description, website, and logo information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->