### PR TITLE
Add ESLint to API project

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from "@repo/eslint-config/base";
+
+export default [...config];

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,8 @@
 {
   "name": "api",
   "scripts": {
-    "dev": "bun run --hot src/index.ts"
+    "dev": "bun run --hot src/index.ts",
+    "lint": "eslint . --ext .ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.821.0",
@@ -17,6 +18,8 @@
     "@types/pg": "^8.15.4",
     "drizzle-kit": "^0.31.1",
     "tsx": "^4.19.4",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@repo/eslint-config": "*",
+    "eslint": "^9.28.0"
   }
 }

--- a/apps/api/src/controllers/distributors.controller.test.ts
+++ b/apps/api/src/controllers/distributors.controller.test.ts
@@ -32,7 +32,7 @@ vi.mock('../db', () => ({
 const mockJson = vi.fn();
 const mockReqJson = vi.fn();
 
-const mockContext = (body?: any, params?: Record<string, string>) => ({
+const mockContext = (body?: Record<string, unknown>, params?: Record<string, string>) => ({
   req: {
     json: mockReqJson.mockResolvedValue(body || {}),
     param: (key: string) => params?.[key]

--- a/bun.lock
+++ b/bun.lock
@@ -21,9 +21,11 @@
         "zod": "^3.23.8",
       },
       "devDependencies": {
+        "@repo/eslint-config": "*",
         "@types/bun": "latest",
         "@types/pg": "^8.15.4",
         "drizzle-kit": "^0.31.1",
+        "eslint": "^9.28.0",
         "tsx": "^4.19.4",
         "vitest": "^1.6.0",
       },


### PR DESCRIPTION
## Summary
- add eslint config and script for API
- fix lint warning in distributors controller test

## Testing
- `bun run lint`
- `cd apps/api && bun x eslint src/controllers/distributors.controller.test.ts && echo ESLINT_OK`


------
https://chatgpt.com/codex/tasks/task_e_684001676efc8331885abbf871b7cf3c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added ESLint configuration and scripts to enable linting of TypeScript files in the API app.
  - Introduced shared ESLint configuration for consistent code quality.

- **Tests**
  - Improved type safety in test code by refining the type annotation for mock request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->