### PR TITLE
Implement Game CRUD UI

### DIFF
--- a/apps/web/app/dashboard/games/[id]/edit/page.tsx
+++ b/apps/web/app/dashboard/games/[id]/edit/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useRouter, useParams } from 'next/navigation';
+import { GameForm } from '@/components/games/game-form';
+import { useGame } from '@/features/games/api/use-games';
+
+export default function EditGamePage() {
+  const router = useRouter();
+  const params = useParams();
+  const id = Number(params?.id);
+  const { data: game } = useGame(isNaN(id) ? 0 : id);
+
+  if (!game) return <div>Loading...</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Edit Game</h1>
+      <GameForm game={game} onSuccess={() => router.push('/dashboard/games')} />
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/games/new/page.tsx
+++ b/apps/web/app/dashboard/games/new/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useRouter } from 'next/navigation';
+import { GameForm } from '@/components/games/game-form';
+
+export default function NewGamePage() {
+  const router = useRouter();
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">New Game</h1>
+      <GameForm onSuccess={() => router.push('/dashboard/games')} />
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/games/page.tsx
+++ b/apps/web/app/dashboard/games/page.tsx
@@ -1,109 +1,24 @@
-import { Suspense } from "react";
-import { getAllGames } from "@/features/games/api/actions";
-import { GameCard } from "@/components/games/game-card";
-import type { Game } from "@/types/game";
+"use client";
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { GameTable } from '@/components/games/game-table';
+import { useGames } from '@/features/games/api/use-games';
 
-// Loading component for the games grid
-function GamesGridSkeleton() {
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
-      {Array.from({ length: 10 }).map((_, i) => (
-        <div
-          key={i}
-          className="h-48 rounded-lg bg-muted/50 animate-pulse border border-border/50"
-        />
-      ))}
-    </div>
-  );
-}
-
-// Games grid component
-async function GamesGrid() {
-  try {
-    const games = await getAllGames();
-
-    if (!games || games.length === 0) {
-      return (
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="h-16 w-16 rounded-full bg-muted/50 flex items-center justify-center mb-4">
-            <span className="text-2xl">🎮</span>
-          </div>
-          <h3 className="text-lg font-semibold text-foreground mb-2">
-            No games found yet
-          </h3>
-          <p className="text-muted-foreground max-w-md">
-            The game list appears to be empty right now. New games will appear here when they are added.
-          </p>
-        </div>
-      );
-    }
-
-    return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
-        {games.map((game: Game) => (
-          <GameCard
-            key={game.id}
-            game={game}
-            onClick={() => {
-              // TODO: Navigate to game detail page
-              console.log(`Clicked on game: ${game.name}`);
-            }}
-          />
-        ))}
-      </div>
-    );
-  } catch (error) {
-    console.error("Error loading games:", error);
-
-    return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="h-16 w-16 rounded-full bg-destructive/20 flex items-center justify-center mb-4">
-          <span className="text-2xl text-destructive">⚠️</span>
-        </div>
-        <h3 className="text-lg font-semibold text-foreground mb-2">
-          Error loading games
-        </h3>
-        <p className="text-muted-foreground max-w-md">
-          There was a problem loading the game list. Please refresh the page or try again later.
-        </p>
-      </div>
-    );
-  }
-}
-
-// Main page component
 export default function GamesPage() {
+  const router = useRouter();
+  const { data } = useGames();
+
+  if (!data) return <div>Loading...</div>;
+
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <div className="border-b border-border/50 bg-card/50 backdrop-blur-sm sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-foreground mb-2">
-                Games
-              </h1>
-              <p className="text-muted-foreground">
-                Discover all available games and find your favorites
-              </p>
-            </div>
-
-            {/* Future: Add search/filter controls here */}
-            <div className="hidden md:flex items-center space-x-2">
-              <div className="h-8 w-8 rounded-full bg-primary/20 flex items-center justify-center">
-                <span className="text-primary text-sm font-bold">🎮</span>
-              </div>
-            </div>
-          </div>
-        </div>
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Games</h1>
+        <Link href="/dashboard/games/new" className="text-sm underline">
+          New Game
+        </Link>
       </div>
-
-      {/* Main content */}
-      <div className="container mx-auto px-4 py-8">
-        <Suspense fallback={<GamesGridSkeleton />}>
-          <GamesGrid />
-        </Suspense>
-      </div>
+      <GameTable data={data} onEdit={(g) => router.push(`/dashboard/games/${g.id}/edit`)} />
     </div>
   );
 }

--- a/apps/web/components/games/game-form.tsx
+++ b/apps/web/components/games/game-form.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { createGameSchema, updateGameSchema } from '@repo/shared';
+import { useCreateGame, useUpdateGame } from '@/features/games/api/use-games';
+import type { Game } from '@/types/game';
+
+export function GameForm({
+  game,
+  onSuccess,
+}: {
+  game?: Game;
+  onSuccess?: () => void;
+}) {
+  const createMutation = useCreateGame();
+  const updateMutation = useUpdateGame(game?.id ?? 0);
+  const mutation = game ? updateMutation : createMutation;
+
+  const form = useForm<z.infer<typeof createGameSchema>>({
+    resolver: zodResolver(game ? updateGameSchema : createGameSchema),
+    defaultValues: {
+      name: game?.name ?? '',
+      description: game?.description ?? '',
+      logo: game?.logo ?? '',
+    },
+  });
+
+  function onSubmit(values: z.infer<typeof createGameSchema>) {
+    mutation.mutate(values, {
+      onSuccess: () => {
+        form.reset();
+        onSuccess?.();
+      },
+    });
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="logo"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Logo</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={mutation.isPending}>
+          {game ? 'Update' : 'Create'}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/apps/web/components/games/game-table.tsx
+++ b/apps/web/components/games/game-table.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { Button } from '@/components/ui/button';
+import { useDeleteGame } from '@/features/games/api/use-games';
+import type { Game } from '@/types/game';
+
+export function GameTable({ data, onEdit }: { data: Game[]; onEdit: (g: Game) => void }) {
+  const deleteMutation = useDeleteGame();
+
+  const columns: ColumnDef<Game>[] = [
+    { accessorKey: 'id', header: 'ID' },
+    { accessorKey: 'name', header: 'Name' },
+    { accessorKey: 'description', header: 'Description' },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => (
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit(row.original)}>
+            Edit
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => deleteMutation.mutate(row.original.id)}
+            disabled={deleteMutation.isPending}
+          >
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        {table.getHeaderGroups().map((hg) => (
+          <tr key={hg.id} className="border-b">
+            {hg.headers.map((h) => (
+              <th key={h.id} className="p-2 text-left">
+                {h.isPlaceholder ? null : flexRender(h.column.columnDef.header, h.getContext())}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id} className="border-b hover:bg-muted/50">
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id} className="p-2">
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/features/games/api/actions.ts
+++ b/apps/web/features/games/api/actions.ts
@@ -1,4 +1,5 @@
-import type { GamesResponse } from "@/types/game";
+import { createGameSchema, updateGameSchema } from "@repo/shared";
+import type { Game, GamesResponse } from "@/types/game";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
 
@@ -20,6 +21,73 @@ export async function getAllGames(): Promise<GamesResponse> {
     return games;
   } catch (error) {
     console.error("Error fetching games:", error);
+    throw error;
+  }
+}
+
+export async function getGame(id: number): Promise<Game> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/games/${id}`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch game: ${res.status}`);
+    }
+    return res.json();
+  } catch (error) {
+    console.error("Error fetching game:", error);
+    throw error;
+  }
+}
+
+export async function createGame(data: unknown): Promise<Game> {
+  try {
+    const parsed = createGameSchema.parse(data);
+    const res = await fetch(`${API_BASE_URL}/games`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to create game: ${res.status}`);
+    }
+    return res.json();
+  } catch (error) {
+    console.error("Error creating game:", error);
+    throw error;
+  }
+}
+
+export async function updateGame(id: number, data: unknown): Promise<Game> {
+  try {
+    const parsed = updateGameSchema.parse(data);
+    const res = await fetch(`${API_BASE_URL}/games/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to update game: ${res.status}`);
+    }
+    return res.json();
+  } catch (error) {
+    console.error("Error updating game:", error);
+    throw error;
+  }
+}
+
+export async function deleteGame(id: number): Promise<void> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/games/${id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to delete game: ${res.status}`);
+    }
+  } catch (error) {
+    console.error("Error deleting game:", error);
     throw error;
   }
 }

--- a/apps/web/features/games/api/use-games.ts
+++ b/apps/web/features/games/api/use-games.ts
@@ -1,1 +1,45 @@
-// This is for react-query
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getAllGames,
+  getGame,
+  createGame,
+  updateGame,
+  deleteGame,
+} from './actions';
+import type { Game } from '@/types/game';
+
+export function useGames() {
+  return useQuery({ queryKey: ['games'], queryFn: getAllGames });
+}
+
+export function useGame(id: number) {
+  return useQuery({
+    queryKey: ['game', id],
+    queryFn: () => getGame(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateGame() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createGame,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['games'] }),
+  });
+}
+
+export function useUpdateGame(id: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: Partial<Game>) => updateGame(id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['games'] }),
+  });
+}
+
+export function useDeleteGame() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteGame,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['games'] }),
+  });
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -8,3 +8,8 @@ export {
   createDistributorSchema,
   updateDistributorSchema,
 } from "./schemas/distributor.schema";
+
+export {
+  createGameSchema,
+  updateGameSchema,
+} from "./schemas/game.schema";

--- a/packages/shared/schemas/game.schema.ts
+++ b/packages/shared/schemas/game.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const createGameSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(150, { message: "Name must be 150 characters or less" })
+    .trim(),
+  description: z.string().optional().nullable(),
+  logo: z.string().max(255, { message: "Logo must be 255 characters or less" }).optional().nullable(),
+});
+
+export const updateGameSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name cannot be empty" })
+    .max(150, { message: "Name must be 150 characters or less" })
+    .trim()
+    .optional(),
+  description: z.string().optional().nullable(),
+  logo: z.string().max(255, { message: "Logo must be 255 characters or less" }).optional().nullable(),
+});


### PR DESCRIPTION
## Summary
- add shared game schema
- extend game API actions and React Query hooks
- add GameForm and GameTable components
- add dashboard pages for listing, creating and editing games

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build` *(fails: Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68407a1d0e588331b9be9555c112b59a